### PR TITLE
Fixed inconsistency with donation addresses links

### DIFF
--- a/web/queue/index.html
+++ b/web/queue/index.html
@@ -49,7 +49,7 @@
         <a href="litecoin:MK7jfGG48RTsETCXTAz1wP27uVoFhBUV5o"><div class="qrcontainer"><span class="cover pixelated qrcode" style="width:148px; height:148px; background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACUAAAAlAQMAAAD/ULJAAAAABlBMVEX///8AAABVwtN+AAAA00lEQVQI12NABvb7a/sfMCjsy16hwKA3pTV7AYNejzaInKvMvYBBYbpqhwKD/apV6x8wMMgcc2BgEPir/iGBQYDl6rEEBraHExkPMIjbWzk3MGjMvF7lwGAlJRG7gEFludWuAwyceTnuCxiMWv3bHjAIWXfVHmCQvbTs5gIGdT6Z/AcMvHM6DzEw2HjfEWtg0H2k1HmAQS1sU+cDBrM5Mf+A1qifWtzAYL9l5uoDDAqNTMlA90x8vs+BQW/al09Ad7bul05gUNjyLQyoppOr1gHZQwBzTUeVN9V6gwAAAABJRU5ErkJggg==);"></span><img class="qrlogo" src="ltc-32px.png" alt=""/></div></a>
         <p>Donation
 	bitcoin:<a href="bitcoin:3LrXizKejCGYyGUxYzGweyuxFVtfs3odEe">3LrXizKejCGYyGUxYzGweyuxFVtfs3odEe</a> (Segwit)<br/>
-        <a href="bitcoincash:qqc0a3s49uzj329rju4v27erlc6kx5paqs6t5l70n6">bitcoincash:qqc0a3s49uzj329rju4v27erlc6kx5paqs6t5l70n6</a><br/>
+        bitcoincash:<a href="bitcoincash:qqc0a3s49uzj329rju4v27erlc6kx5paqs6t5l70n6">qqc0a3s49uzj329rju4v27erlc6kx5paqs6t5l70n6</a><br/>
 	litecoin:<a href="litecoin:MK7jfGG48RTsETCXTAz1wP27uVoFhBUV5o">MK7jfGG48RTsETCXTAz1wP27uVoFhBUV5o</a><br/>
 	ethereum: <span class="cover pixelated" style="width: 20px;height:20px; background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAgMAAAC5YVYYAAAACVBMVEWV5Xgyfg0qispl6+N0AAAAH0lEQVQI12NwYGRwdGQIDWVQkWBwEWSYwMagNgMoAgAqGwPVVzuqWQAAAABJRU5ErkJggg==); border-radius: 50%; display: inline-block;"></span>&nbsp;mempool.hoenicke.eth</p>
     </div>


### PR DESCRIPTION
For all other coins the link was the address only but the Bitcoin Cash link text included the coin prefix "bitcoincash:" which none of the others did. This is only a graphical inconsistency no functionality is changed.