### PR TITLE
`bitcoin-cli getrawmempool true` output is now "vsize".

### DIFF
--- a/mempool_sql.py
+++ b/mempool_sql.py
@@ -19,8 +19,8 @@ found = False
 
 def parse_txdata(obj):
     global sizes, count, fees, found
-    if "size" in obj:
-        size = obj["size"]
+    if "vsize" in obj:
+        size = obj["vsize"]
         fee = int(obj["fee"]*100000000)
         if "ancestorsize" in obj:
             asize = obj["ancestorsize"]


### PR DESCRIPTION
While trivial to code for current and backwards compatibility, upgrading bitcoind/bitcoin-cli is preferred in my opinion, but I defer to jhoenicke.