### PR TITLE
Fix “application/json” is not a valid JavaScript MIME type

### DIFF
--- a/web/queue/db.php
+++ b/web/queue/db.php
@@ -45,7 +45,7 @@ try {
     $query = $db->prepare("SELECT * FROM mempool WHERE time >= :start AND time < :end and (time DIV 60) MOD :increment = 0 ORDER BY time");
 
     $query->execute(array(':start' => $start, ':end' => $end, ':increment' => $increment));
-    header("Content-Type: application/json; charset=UTF-8");
+    header("Content-Type: application/javascript; charset=UTF-8");
     echo 'call([';
     $comma="";
     while ($row = $query->fetch(PDO::FETCH_NUM)) {


### PR DESCRIPTION
Fix error `The script from “https://johoe.jochen-hoenicke.de/queue/db.php?s=1594278003&e=1594278919&i=1” was loaded even though its MIME type (“application/json”) is not a valid JavaScript MIME type.`

Change outdated  application/json to application/javascript as per https://www.rfc-editor.org/rfc/rfc4329.txt